### PR TITLE
[CRITEO] - Authorize scylla nodes to get labels from nodes

### DIFF
--- a/helm/scylla/templates/rbac.yaml
+++ b/helm/scylla/templates/rbac.yaml
@@ -10,6 +10,7 @@ rules:
       - ""
     resources:
       - pods
+      - nodes
     verbs:
       - get
   - apiGroups:


### PR DESCRIPTION
Used to get rack label from nodes