### PR TITLE
MultiDc Feature

### DIFF
--- a/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
+++ b/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
@@ -1438,6 +1438,18 @@ spec:
                   description: PollInterval specifies how often upgrade logic polls on state updates. Increasing this value should lower number of requests sent to apiserver, but it may affect overall time spent during upgrade.
                   type: string
               type: object
+            multiDcCluster:
+              description: Configuration for multi DC cluster
+              properties:
+                initCluster:
+                  description: Indicate if this cluster is the initial cluster. Init cluster rely on local seeds while non init one only rely on multi dc seeds during bootstrap and then on local seeds only.
+                  type: boolean
+                seeds:
+                  description: List of seeds.
+                  items:
+                    type: string
+                  type: array
+              type: object
             network:
               description: Networking config
               properties:
@@ -1577,6 +1589,9 @@ spec:
                 - name
                 type: object
               type: array
+            bootstrap:
+              description: bootstrap indicate if the cluster has been well bootstrap from multi dc seed.
+              type: string
             managerId:
               description: ManagerID contains ID under which cluster was registered in Scylla Manager.
               type: string

--- a/docs/design/MultiDc.md
+++ b/docs/design/MultiDc.md
@@ -1,0 +1,58 @@
+# Multi Data Centers Clusters
+
+## Context
+
+This design doc will describe how to implement the support of multi dc cluster on the scylla operator.
+
+See https://docs.scylladb.com/operating-scylla/procedures/cluster-management/create_cluster_multidc/ 
+for more detail on this scylla feature
+
+As a first step only hostNetwork cluster will support this feature.
+
+It is probably possible to extend this to non hostNetwork cluster if a solution (outside of the scylla operator scope) is available
+to ensure pods of each sites can reach pods from other sites (For ex.: https://docs.projectcalico.org/networking/determine-best-networking#pod-ip-routability-outside-of-the-cluster)
+
+## Design
+
+The design will be split in 2 parts:
+- Exposing PodIP instead of member service IP
+- Providing multi dc feature
+
+### Exposing PodIP instead of member service IP
+
+Current implementation of the hostNetwork cluster expose the member service IP, which is an IP only accessible from local kubernetes clusters, as the member address on pods.
+Due to this each pods from a cluster will not be able to reach other sites pods. As this is a mandatory feature to be able to activate multi dc we will first ensure that the PodIP is used as the member address.
+
+Exposing PodIP will still rely on the member service to provide the member address to the sidecar operator (listen-address, broadcast-address, seeds ip...) and other operator actions that require it (replace, upgrade, cluster status).
+A specific label scylla/ip will be added to the member service with the PodIP in the MemberServiceForPod function for hostNetwork clusters.
+All part of code that will require to get the member address will be updated to get IP from a common function GetIpFromService. This function will return member service clusterIP for non hostNetwork cluster or the scylla/ip label value if hostNetwork cluster.
+
+The member service cluster IP will be set to None to avoid confusion on IP used as member address for hostNetwork clusters.
+
+Member service are created when a reconcile request from the statefulset is issued.
+As the pod can still be in pending state the member service could be created without the scylla/ip label set.
+When the pod state change to Running the PodIP can be set but no reconcile request will be emitted by the statefulset as there will be no update on the members.
+In order to update the member service with the this PodIP we will have to add a watcher on pod events with a predicate to filter events for pods with label app.kubernetes.io/managed-by=scylla-operator.
+Those events will be managed by a specific events handler to be able to retrieve statefulset owner and then the scyllacluster owner.
+
+
+### Providing multi dc feature
+
+A specific field multiDcCluster will be added to the ScyllaCluster CRD in order to enable multi dc feature on a cluster.
+
+2 properties will be added to that field:
+
+- list of seeds (ip or dns entries) that will be used as remote seeds to use to bootstrap multi dc clusters.
+- init cluster boolean that will indicate if the current cluster is the first cluster from the multi dc cluster. This first cluster will be allowed to bootstrap without the remote seeds as it will be the reference clusters for other dc members.
+
+For each entry of the seeds list a multi dc service will be created.
+This creation will be managed by a specific step in the sync function before cluster member services.
+Each multi dc services will be created with the scylla/ip label storing the related ip/dns of the remote seed and a specific scylla/multi-dc-seed label to easily select those multi dc seeds service on the sidecar operator.
+
+The operator will have to manage multi dc bootstrap in 2 different ways depending on the init cluster value.
+
+- If the cluster is the init cluster the sidecar operator will not have to take multi dc service when selecting seeds in GetSeeds function. In fact this cluster will only rey on the local seed during bootstrap and run.
+- If the cluster is not the init cluster the sidecar operator will have to enforce the bootstrap of the cluster from the remote seed. It will only select the multi dc service and won't take in account local one during the bootstrap in GetSeeds function.
+Once the cluster is boostrap successfully it will rely back on local seeds only.
+In order to know if the cluster has been well bootstrap a new Status parameter bootstrap will be added to the ScyllaCluster CRD. This field will contains a specific string ("ongoing" or "finished") so the sidecar can rely on this information to do appropriate seeds selection.
+The status will be updated by the operator when updating status in the updateStatus function. The boostratp state will be set to finished once all pods will be in ready state for all required statefulsets. The state will never been rollbacked by the operator once set to finished.

--- a/docs/source/scylla_cluster_crd.md
+++ b/docs/source/scylla_cluster_crd.md
@@ -96,7 +96,9 @@ spec:
     * `dnsPolicy`: controls Scylla Pod DNS Policy. See [details](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 * `repairs`: Optional field. Repair tasks definitions. See `Scylla Manager settings` for details.
 * `backups`: Optional field. Repair tasks definitions. See `Scylla Manager settings` for details.
-
+* `multiDcCluster`: Optional field. Allow to configure multi data center cluster. This feature is only supported with hostNetworking enabled. See [details](https://docs.scylladb.com/operating-scylla/procedures/cluster-management/create_cluster_multidc/).
+    * `initCluster`: Optional field. Indicate if this cluster is the initial cluster. Init cluster rely on local seeds while non init one only rely on multi dc seeds during bootstrap and then on local seeds only.
+    * `seeds`: Optional field. List of seeds .
 
 In the Scylla model, each cluster contains datacenters and each datacenter contains racks. At the moment, the operator only supports single datacenter setups.
 

--- a/helm/scylla/templates/cluster.yaml
+++ b/helm/scylla/templates/cluster.yaml
@@ -16,6 +16,14 @@ spec:
   {{- end }}
   developerMode: {{ .Values.developerMode }}
   cpuset: {{ .Values.cpuset }}
+  {{- if .Values.multiDcCluster.enabled }}
+  multiDcCluster:
+    initCluster: {{ .Values.multiDcCluster.initCluster }}
+    {{- with .Values.multiDcCluster.seeds }}
+    seeds:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
   automaticOrphanedNodeCleanup: {{ .Values.automaticOrphanedNodeCleanup }}
   {{- with .Values.sysctls }}
   sysctls:

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -39,6 +39,14 @@ automaticOrphanedNodeCleanup: false
 # Sysctl properties to be applied during initialization given as a list of key=value pairs
 sysctls: []
 
+# Activate multi DC cluster and define external seeds
+multiDcCluster:
+  enabled: false
+  # Indicate if this cluster is the initial cluster.
+  # Cluster will rely on internal seeds and won't wait for external seeds to be available otherwise clusters will only rely on external seeds
+  initCluster: false
+  seeds: []
+
 # Scylla Manager Backups task definition
 backups: []
 # Scylla Manager Repair task definition

--- a/pkg/api/v1/cluster_types.go
+++ b/pkg/api/v1/cluster_types.go
@@ -63,6 +63,9 @@ type ClusterSpec struct {
 	// Backups specifies backup task in Scylla Manager.
 	// When Scylla Manager is not installed, these will be ignored.
 	Backups []BackupTaskSpec `json:"backups,omitempty"`
+	// MultiDcCluster configuration for multi DC cluster
+	// Specifies the external seed to use
+	MultiDcCluster *MultiDcClusterSpec `json:"multiDcCluster,omitempty"`
 }
 
 // GenericUpgradeFailureStrategy allows to specify how upgrade logic should handle failures.
@@ -124,6 +127,11 @@ type RepairTaskSpec struct {
 	SmallTableThreshold *string `json:"smallTableThreshold,omitempty" mapstructure:"small_table_threshold,omitempty"`
 	// Host to repair, by default all hosts are repaired
 	Host *string `json:"host,omitempty" mapstructure:"host,omitempty"`
+}
+
+type MultiDcClusterSpec struct {
+	InitCluster bool     `json:"initCluster,omitempty"`
+	Seeds       []string `json:"seeds,omitempty" mapstructure:"seeds,omitempty"`
 }
 
 type BackupTaskSpec struct {
@@ -239,6 +247,10 @@ func (a *AlternatorSpec) Enabled() bool {
 	return a != nil && a.Port > 0
 }
 
+func (m *MultiDcClusterSpec) Enabled() bool {
+	return m != nil
+}
+
 type RepairTaskStatus struct {
 	RepairTaskSpec `json:",inline" mapstructure:",squash"`
 	ID             string `json:"id"`
@@ -263,6 +275,8 @@ type ClusterStatus struct {
 	Backups []BackupTaskStatus `json:"backups,omitempty"`
 	// Upgrade reflects state of ongoing upgrade procedure.
 	Upgrade *UpgradeStatus `json:"upgrade,omitempty"`
+	// Bootstrap indicate if the cluster has been well bootstrap from multi dc seed.
+	Bootstrap string `json:"bootstrap,omitempty"`
 }
 
 // UpgradeStatus contains state of ongoing upgrade procedure.

--- a/pkg/api/v1/cluster_validation.go
+++ b/pkg/api/v1/cluster_validation.go
@@ -113,6 +113,12 @@ func checkValues(c *ScyllaCluster) error {
 		}
 	}
 
+	if c.Spec.MultiDcCluster.Enabled() {
+		if !c.Spec.Network.HostNetworking {
+			return errors.Errorf("MultiDcCluster is only supported on hostNetworking cluster")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/api/v1/cluster_validation_test.go
+++ b/pkg/api/v1/cluster_validation_test.go
@@ -40,6 +40,11 @@ func TestCheckValues(t *testing.T) {
 		},
 	})
 
+	nonValidMultiDcCluster := validCluster.DeepCopy()
+	nonValidMultiDcCluster.Spec.MultiDcCluster = &v1.MultiDcClusterSpec{
+		Seeds: []string{"10.10.10.10", "20.20.20.20"},
+	}
+
 	tests := []struct {
 		name    string
 		obj     *v1.ScyllaCluster
@@ -63,6 +68,11 @@ func TestCheckValues(t *testing.T) {
 		{
 			name:    "non-unique names in manager tasks spec",
 			obj:     nonUniqueManagerTaskNames,
+			allowed: false,
+		},
+		{
+			name:    "hostNetworking not enabled with multi dc",
+			obj:     nonValidMultiDcCluster,
 			allowed: false,
 		},
 	}

--- a/pkg/controllers/cluster/actions/replace.go
+++ b/pkg/controllers/cluster/actions/replace.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-log"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
@@ -136,8 +137,12 @@ func (a *RackReplaceNode) replaceNode(ctx context.Context, state *State, member 
 
 	// Save replace address in RackStatus
 	rackStatus := c.Status.Racks[r.Name]
-	rackStatus.ReplaceAddressFirstBoot[member.Name] = member.Spec.ClusterIP
-	a.Logger.Debug(ctx, "Adding member address to replace address list", "member", member.Name, "ip", member.Spec.ClusterIP, "replace_addresses", rackStatus.ReplaceAddressFirstBoot)
+	memberIp, err := resource.GetIpFromService(member, c)
+	if err != nil {
+		return errors.Wrap(err, "failed to get IP from member service")
+	}
+	rackStatus.ReplaceAddressFirstBoot[member.Name] = memberIp
+	a.Logger.Debug(ctx, "Adding member address to replace address list", "member", member.Name, "ip", memberIp, "replace_addresses", rackStatus.ReplaceAddressFirstBoot)
 
 	// Proceed to destructive operations only when IP address is saved in cluster Status.
 	if err := cc.Status().Update(ctx, c); err != nil {

--- a/pkg/controllers/cluster/actions/upgrade_version.go
+++ b/pkg/controllers/cluster/actions/upgrade_version.go
@@ -90,9 +90,13 @@ func (a *ClusterVersionUpgrade) nonMaintenanceHosts(ctx context.Context) ([]stri
 		}
 
 		for _, s := range services {
-			a.ipMapping[s.Name] = s.Spec.ClusterIP
+			ip, err := resource.GetIpFromService(&s, a.Cluster)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get IP from member service")
+			}
+			a.ipMapping[s.Name] = ip
 			if _, ok := s.Labels[naming.NodeMaintenanceLabel]; !ok {
-				hosts = append(hosts, s.Spec.ClusterIP)
+				hosts = append(hosts, ip)
 			}
 		}
 	}

--- a/pkg/controllers/cluster/pod_event.go
+++ b/pkg/controllers/cluster/pod_event.go
@@ -1,0 +1,201 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+var _ handler.EventHandler = &EnqueueRequestForPod{}
+
+// EnqueueRequestForPod enqueues Requests for the Owners of an object.  E.g. the object that created
+// the object that was the source of the Event.
+//
+// If a ReplicaSet creates Pods, users may reconcile the ReplicaSet in response to Pod Events using:
+//
+// - a source.Kind Source with Type of Pod.
+//
+// - a handler.EnqueueRequestForPod EventHandler with an OwnerType of ReplicaSet and IsController set to true.
+type EnqueueRequestForPod struct {
+	// groupStsKind is the cached Group and Kind for sts OwnerType
+	groupStsKind schema.GroupKind
+
+	// groupClusterKind is the cached Group and Kind for ScyllaCluster OwnerType
+	groupClusterKind schema.GroupKind
+
+	// mapper maps GroupVersionKinds to Resources
+	mapper meta.RESTMapper
+
+	KubeClient kubernetes.Interface
+}
+
+// Create implements EventHandler
+func (e *EnqueueRequestForPod) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.Meta) {
+		q.Add(req)
+	}
+}
+
+// Update implements EventHandler
+func (e *EnqueueRequestForPod) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.MetaOld) {
+		q.Add(req)
+	}
+	for _, req := range e.getOwnerReconcileRequest(evt.MetaNew) {
+		q.Add(req)
+	}
+}
+
+// Delete implements EventHandler
+func (e *EnqueueRequestForPod) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.Meta) {
+		q.Add(req)
+	}
+}
+
+// Generic implements EventHandler
+func (e *EnqueueRequestForPod) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.Meta) {
+		q.Add(req)
+	}
+}
+
+// generateGroupKind generate Group and Kind and caches the result for sts and ScyllaCluster type.  Returns false
+// if sts or ScyllaCluster type could not be parsed using the scheme.
+func (e *EnqueueRequestForPod) generateGroupKind(scheme *runtime.Scheme) error {
+	// Get the kinds of the type
+	stsType := &appsv1.StatefulSet{}
+	clusterType := &scyllav1.ScyllaCluster{}
+
+	kindsSts, _, err := scheme.ObjectKinds(stsType)
+	if err != nil {
+		return err
+	}
+	kindsCluster, _, err := scheme.ObjectKinds(clusterType)
+	if err != nil {
+		return err
+	}
+	// Expect only 1 kind.  If there is more than one kind this is probably an edge case such as ListOptions.
+	if len(kindsSts) != 1 {
+		err := fmt.Errorf("Expected exactly 1 kind for OwnerType %T, but found %s kinds", stsType, kindsSts)
+		return err
+
+	}
+	// Expect only 1 kind.  If there is more than one kind this is probably an edge case such as ListOptions.
+	if len(kindsCluster) != 1 {
+		err := fmt.Errorf("Expected exactly 1 kind for OwnerType %T, but found %s kinds", clusterType, kindsCluster)
+		return err
+
+	}
+	// Cache the Group and Kind for the OwnerType
+	e.groupStsKind = schema.GroupKind{Group: kindsSts[0].Group, Kind: kindsSts[0].Kind}
+	e.groupClusterKind = schema.GroupKind{Group: kindsCluster[0].Group, Kind: kindsCluster[0].Kind}
+	return nil
+}
+
+// getOwnerReconcileRequest looks at object and returns a slice of reconcile.Request to reconcile
+// owners of object that match the ScyllaCluster type through the sts type
+func (e *EnqueueRequestForPod) getOwnerReconcileRequest(object metav1.Object) []reconcile.Request {
+	// Iterate through the OwnerReferences looking for a match on Group and Kind against what was requested
+	// by the user
+	var result []reconcile.Request
+	for _, ref := range e.getOwnersReferences(object) {
+		// Parse the Group out of the OwnerReference to compare it
+		refGV, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil {
+			return nil
+		}
+
+		// Compare the OwnerReference Group and Kind against the sts Group and Kind.
+		// If the two match, get the reconcile request from the ScyllaCluster type owner
+		if ref.Kind == e.groupStsKind.Kind && refGV.Group == e.groupStsKind.Group {
+			// Get sts and then get ScyllaCluster reference
+			sts, err := e.KubeClient.AppsV1().StatefulSets(object.GetNamespace()).Get(context.Background(), ref.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil
+			}
+			resultSts := e.getStsOwnerReconcileRequest(sts.GetObjectMeta())
+
+			result = append(result, resultSts...)
+		}
+	}
+
+	// Return the matches
+	return result
+}
+
+// getStsOwnerReconcileRequest looks at object and returns a slice of reconcile.Request to reconcile
+// owners of object that match ScyllaCluster type
+func (e *EnqueueRequestForPod) getStsOwnerReconcileRequest(object metav1.Object) []reconcile.Request {
+	// Iterate through the OwnerReferences looking for a match on Group and Kind against what was requested
+	// by the user
+	var result []reconcile.Request
+	for _, ref := range e.getOwnersReferences(object) {
+		// Parse the Group out of the OwnerReference to compare it
+		refGV, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil {
+			return nil
+		}
+
+		// Compare the OwnerReference Group and Kind against the ScyllaCluster Group and Kind.
+		// If the two match, create a Request for the objected referred to by
+		// the OwnerReference.  Use the Name from the OwnerReference and the Namespace from the
+		// object in the event.
+		if ref.Kind == e.groupClusterKind.Kind && refGV.Group == e.groupClusterKind.Group {
+			// Match found - add a Request for the object referred to in the OwnerReference
+			request := reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: ref.Name,
+			}}
+
+			request.Namespace = object.GetNamespace()
+
+			result = append(result, request)
+		}
+	}
+
+	// Return the matches
+	return result
+}
+
+// getOwnersReferences returns the OwnerReferences for an object as specified by the EnqueueRequestForOwner
+// - if IsController is true: only take the Controller OwnerReference (if found)
+// - if IsController is false: take all OwnerReferences
+func (e *EnqueueRequestForPod) getOwnersReferences(object metav1.Object) []metav1.OwnerReference {
+	if object == nil {
+		return nil
+	}
+
+	// If filtered to a Controller, only take the Controller OwnerReference
+	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
+		return []metav1.OwnerReference{*ownerRef}
+	}
+	// No Controller OwnerReference found
+	return nil
+}
+
+var _ inject.Scheme = &EnqueueRequestForPod{}
+
+// InjectScheme is called by the Controller to provide a singleton scheme to the EnqueueRequestForOwner.
+func (e *EnqueueRequestForPod) InjectScheme(s *runtime.Scheme) error {
+	return e.generateGroupKind(s)
+}
+
+var _ inject.Mapper = &EnqueueRequestForPod{}
+
+// InjectMapper  is called by the Controller to provide the rest mapper used by the manager.
+func (e *EnqueueRequestForPod) InjectMapper(m meta.RESTMapper) error {
+	e.mapper = m
+	return nil
+}

--- a/pkg/controllers/cluster/resource/resource_test.go
+++ b/pkg/controllers/cluster/resource/resource_test.go
@@ -1,0 +1,47 @@
+package resource
+
+import (
+	"fmt"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"testing"
+)
+
+func TestGetIpFromService(t *testing.T) {
+	cluster := unit.NewSingleRackCluster(1)
+
+	clusterIp := "10.10.10.10"
+	podIp := "20.20.20.20"
+	labels := map[string]string{
+		naming.IpLabel: podIp,
+	}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod_service",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: clusterIp,
+		},
+	}
+
+	cluster.Spec.Network.HostNetworking = false
+	ip, _ := GetIpFromService(service, cluster)
+	if ip != clusterIp {
+		t.Error("IP is not well retrieved from service ClusterIp spec")
+	}
+
+	cluster.Spec.Network.HostNetworking = true
+	_, err := GetIpFromService(service, cluster)
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("%s label not found on member service pod_service", naming.IpLabel)) {
+		t.Errorf("No Error or bad error return while %s label is missing on the service: %v", naming.IpLabel, err)
+	}
+
+	service.ObjectMeta.Labels = labels
+	ip, _ = GetIpFromService(service, cluster)
+	if ip != podIp {
+		t.Errorf("IP is not well retrieved from %s label", naming.IpLabel)
+	}
+}

--- a/pkg/controllers/cluster/status.go
+++ b/pkg/controllers/cluster/status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
@@ -121,7 +122,11 @@ func (cc *ClusterReconciler) updateStatus(ctx context.Context, cluster *scyllav1
 					return errors.New("seed node replace is not supported")
 				}
 				if replaceAddr == "" {
-					rackStatus.ReplaceAddressFirstBoot[svc.Name] = svc.Spec.ClusterIP
+					memberIp, err := resource.GetIpFromService(&svc, cluster)
+					if err != nil {
+						return err
+					}
+					rackStatus.ReplaceAddressFirstBoot[svc.Name] = memberIp
 				}
 				cc.Logger.Info(ctx, "Rack member is being replaced", "rack", rack.Name, "member", svc.Name)
 				scyllav1.SetRackCondition(&rackStatus, scyllav1.RackConditionTypeMemberReplacing)

--- a/pkg/controllers/cluster/sync.go
+++ b/pkg/controllers/cluster/sync.go
@@ -17,6 +17,7 @@ import (
 const (
 	// Messages to display when experiencing an error.
 	MessageHeadlessServiceSyncFailed = "Failed to sync Headless Service for cluster"
+	MessageMultiDcServicesSyncFailed = "Failed to sync MultiDcServices for cluster"
 	MessageMemberServicesSyncFailed  = "Failed to sync MemberServices for cluster"
 	MessageUpdateStatusFailed        = "Failed to update status for cluster: %+v"
 	MessageCleanupFailed             = "Failed to clean up cluster resources"
@@ -51,6 +52,14 @@ func (cc *ClusterReconciler) sync(c *scyllav1.ScyllaCluster) error {
 	if err := cc.syncClusterHeadlessService(ctx, c); err != nil {
 		cc.Recorder.Event(c, corev1.EventTypeWarning, naming.ErrSyncFailed, MessageHeadlessServiceSyncFailed)
 		return errors.Wrap(err, "failed to sync headless service")
+	}
+
+	// Sync Multi Dc Services
+	if c.Spec.MultiDcCluster.Enabled() {
+		if err := cc.syncMultiDcServices(ctx, c); err != nil {
+			cc.Recorder.Event(c, corev1.EventTypeWarning, naming.ErrSyncFailed, MessageMultiDcServicesSyncFailed)
+			return errors.Wrap(err, "failed to sync multi dc service")
+		}
 	}
 
 	// Sync Cluster Member Services

--- a/pkg/controllers/sidecar/checks.go
+++ b/pkg/controllers/sidecar/checks.go
@@ -27,7 +27,7 @@ func (mc *MemberReconciler) setupHTTPChecks(ctx context.Context) {
 }
 
 func nodeUnderMaintenance(ctx context.Context, mc *MemberReconciler) (bool, error) {
-	member, err := identity.Retrieve(ctx, mc.member.Name, mc.member.Namespace, mc.kubeClient)
+	member, err := identity.Retrieve(ctx, mc.member.Name, mc.member.Namespace, mc.kubeClient, mc.Client)
 	if err != nil {
 		return false, errors.Wrap(err, "get member service")
 	}

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -188,19 +188,12 @@ func appendScyllaArguments(ctx context.Context, s *ScyllaConfig, scyllaArgs stri
 }
 
 func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
-	m := s.member
-	// Get seeds
-	seeds, err := m.GetSeeds(ctx, s.kubeClient)
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting seeds")
-	}
-
 	// Check if we need to run in developer mode
 	devMode := "0"
 	cluster := &v1.ScyllaCluster{}
-	err = s.Get(ctx, naming.NamespacedName(s.member.Cluster, s.member.Namespace), cluster)
+	err := s.Get(ctx, naming.NamespacedName(s.member.Cluster, s.member.Namespace), cluster)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting cluster")
+		return nil, errors.Wrapf(err, "error getting cluster %s", s.member.Cluster)
 	}
 	if cluster.Spec.DeveloperMode {
 		devMode = "1"
@@ -208,6 +201,13 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 	shards, err := strconv.Atoi(options.GetSidecarOptions().CPU)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	m := s.member
+	// Get seeds
+	seeds, err := m.GetSeeds(ctx, s.kubeClient, cluster)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting seeds for cluster %s", s.member.Cluster)
 	}
 
 	args := map[string]*string{
@@ -219,9 +219,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		"overprovisioned":       pointer.StringPtr("0"),
 		"smp":                   pointer.StringPtr(strconv.Itoa(shards)),
 	}
-	if cluster.Spec.Network.HostNetworking {
-		args["broadcast-rpc-address"] = &m.IP
-	}
+
 	if cluster.Spec.Alternator.Enabled() {
 		args["alternator-port"] = pointer.StringPtr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))
 		if cluster.Spec.Alternator.WriteIsolation != "" {

--- a/pkg/controllers/sidecar/identity/member.go
+++ b/pkg/controllers/sidecar/identity/member.go
@@ -6,11 +6,14 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	v1 "github.com/scylladb/scylla-operator/pkg/api/v1"
 	"github.com/scylladb/scylla-operator/pkg/cmd/scylla-operator/options"
+	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Member encapsulates the identity for a single member
@@ -30,7 +33,7 @@ type Member struct {
 	ServiceLabels map[string]string
 }
 
-func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes.Interface) (*Member, error) {
+func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes.Interface, cc client.Client) (*Member, error) {
 	// Get the member's service
 	var memberService *corev1.Service
 	var err error
@@ -65,11 +68,22 @@ func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes
 		}
 	}
 
+	cluster := &v1.ScyllaCluster{}
+	err = cc.Get(ctx, naming.NamespacedName(pod.Labels[naming.ClusterNameLabel], namespace), cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cluster")
+	}
+
+	memberIp, err := resource.GetIpFromService(memberService, cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Member{
 		Name:          name,
 		Namespace:     namespace,
 		IP:            pod.Status.PodIP,
-		StaticIP:      memberService.Spec.ClusterIP,
+		StaticIP:      memberIp,
 		Rack:          rack,
 		Datacenter:    pod.Labels[naming.DatacenterNameLabel],
 		Cluster:       pod.Labels[naming.ClusterNameLabel],
@@ -77,7 +91,7 @@ func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes
 	}, nil
 }
 
-func (m *Member) GetSeeds(ctx context.Context, kubeClient kubernetes.Interface) ([]string, error) {
+func (m *Member) GetSeeds(ctx context.Context, kubeClient kubernetes.Interface, cluster *v1.ScyllaCluster) ([]string, error) {
 	var services *corev1.ServiceList
 	var err error
 
@@ -97,7 +111,11 @@ func (m *Member) GetSeeds(ctx context.Context, kubeClient kubernetes.Interface) 
 
 	seeds := []string{}
 	for _, svc := range services.Items {
-		seeds = append(seeds, svc.Spec.ClusterIP)
+		seedIp, err := resource.GetIpFromService(&svc, cluster)
+		if err != nil {
+			return nil, err
+		}
+		seeds = append(seeds, seedIp)
 	}
 	return seeds, nil
 }

--- a/pkg/controllers/sidecar/sidecar_controller.go
+++ b/pkg/controllers/sidecar/sidecar_controller.go
@@ -86,20 +86,20 @@ func (mc *MemberReconciler) Reconcile(request reconcile.Request) (reconcile.Resu
 
 // newReconciler returns a new reconcile.Reconciler
 func New(ctx context.Context, mgr manager.Manager, logger log.Logger) (*MemberReconciler, error) {
-	opts := options.GetSidecarOptions()
-	kubeClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
-	member, err := identity.Retrieve(ctx, opts.Name, opts.Namespace, kubeClient)
-	if err != nil {
-		return nil, errors.Wrap(err, "get member")
-	}
-	logger.Info(ctx, "Member loaded", "member", member)
-
 	c, err := client.New(mgr.GetConfig(), client.Options{
 		Scheme: mgr.GetScheme(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "get dynamic client")
 	}
+
+	opts := options.GetSidecarOptions()
+	kubeClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	member, err := identity.Retrieve(ctx, opts.Name, opts.Namespace, kubeClient, c)
+	if err != nil {
+		return nil, errors.Wrap(err, "get member")
+	}
+	logger.Info(ctx, "Member loaded", "member", member)
 
 	host, err := network.FindFirstNonLocalIP()
 	if err != nil {

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -12,6 +12,10 @@ const (
 	// SeedLabel determines if a member is a seed or not.
 	SeedLabel = "scylla/seed"
 
+	// IpLabel determines ip of pod when using hostNetwork
+	// Used for pod replacement, seed ip and listen/broadcast ip
+	IpLabel = "scylla/ip"
+
 	// DecommissionLabel expresses the intent to decommission
 	// the specific member. The presence of the label expresses
 	// the intent to decommission. If the value is true, it means

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -39,6 +39,7 @@ const (
 	ClusterNameLabel    = "scylla/cluster"
 	DatacenterNameLabel = "scylla/datacenter"
 	RackNameLabel       = "scylla/rack"
+	MultiDcSeedLabel    = "scylla/multi-dc-seed"
 
 	AppName         = "scylla"
 	OperatorAppName = "scylla-operator"
@@ -65,6 +66,14 @@ const (
 	// Cluster fails to sync due to a resource of the same name already
 	// existing.
 	ErrSyncFailed = "ErrSyncFailed"
+)
+
+// Bootstrap Values
+const (
+	// BoostrapOngoing indicate cluster is still bootstraping from multi dc seeds
+	BoostrapOngoing = "ongoing"
+	// BoostrapFinished indicate cluster has finished bootstraping from multi dc seeds
+	BoostrapFinished = "finished"
 )
 
 // Configuration Values

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -53,6 +53,15 @@ func RackSelector(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) labels.Selecto
 	return sel
 }
 
+// MultiDcSeedSelector returns a LabelSelector for the external seed service.
+func MultiDcSeedSelector() labels.Selector {
+	sel := labels.SelectorFromSet(map[string]string{
+		MultiDcSeedLabel: LabelValueTrue,
+	})
+
+	return sel
+}
+
 func SelectorForSeeds(clusterName string) string {
 	return fmt.Sprintf("%s,%s=%s", SeedLabel, ClusterNameLabel, clusterName)
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -51,7 +52,7 @@ var _ = Describe("Cluster controller", func() {
 			for _, rack := range scylla.Spec.Datacenter.Racks {
 				for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
 					Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
-					Expect(sst.CreatePods(ctx, scylla)).To(Succeed())
+					Expect(sst.CreatePods(ctx, scylla, false)).To(Succeed())
 				}
 			}
 
@@ -84,7 +85,7 @@ var _ = Describe("Cluster controller", func() {
 		// Cluster should be scaled sequentially up to member count
 		for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
 			Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
-			Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+			Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 			Expect(sstStub.CreatePVCs(ctx, scylla, pvOption)).To(Succeed())
 		}
 
@@ -107,6 +108,41 @@ var _ = Describe("Cluster controller", func() {
 		}).Should(HaveKeyWithValue(naming.ReplaceLabel, ""))
 	})
 
+	It("Set pod ip in scylla/ip member service label with hostNetwork enbaled", func() {
+		scylla := singleNodeCluster(ns)
+		scylla.Spec.Network.HostNetworking = true
+
+		Expect(testEnv.Create(ctx, scylla)).To(Succeed())
+		defer func() {
+			Expect(testEnv.Delete(ctx, scylla)).To(Succeed())
+		}()
+
+		Expect(testEnv.WaitForCluster(ctx, scylla)).To(Succeed())
+		Expect(testEnv.Refresh(ctx, scylla)).To(Succeed())
+
+		sstStub := integration.NewStatefulSetOperatorStub(testEnv)
+		rack := scylla.Spec.Datacenter.Racks[0]
+
+		for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
+			Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
+			Expect(sstStub.CreatePods(ctx, scylla, true, func(pod *corev1.Pod) {
+				pod.Status.PodIP = fmt.Sprintf("20.20.20.20")
+			})).To(Succeed())
+		}
+
+		services, err := rackMemberService(ns.Namespace, rack, scylla)
+		Expect(err).To(BeNil())
+		Expect(services).To(Not(BeEmpty()))
+
+		service := services[0]
+
+		Eventually(func() map[string]string {
+			Expect(testEnv.Refresh(ctx, &service)).To(Succeed())
+
+			return service.Labels
+		}).Should(HaveKeyWithValue(naming.IpLabel, "20.20.20.20"))
+	})
+
 	Context("Node replace", func() {
 		var (
 			scylla  *scyllav1.ScyllaCluster
@@ -126,7 +162,7 @@ var _ = Describe("Cluster controller", func() {
 			rack := scylla.Spec.Datacenter.Racks[0]
 			for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
 				Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
-				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 				Expect(sstStub.CreatePVCs(ctx, scylla)).To(Succeed())
 			}
 		})
@@ -155,7 +191,7 @@ var _ = Describe("Cluster controller", func() {
 				}
 
 				return scylla.Status.Racks[rack.Name].ReplaceAddressFirstBoot, nil
-			}).Should(HaveKeyWithValue(serviceToReplace.Name, replacedServiceIP))
+			}, shortWait).Should(HaveKeyWithValue(serviceToReplace.Name, replacedServiceIP))
 
 			By("Old PVC should be removed")
 			Eventually(func() []corev1.PersistentVolumeClaim {
@@ -180,7 +216,7 @@ var _ = Describe("Cluster controller", func() {
 			}, shortWait).Should(HaveLen(int(rack.Members - 1)))
 
 			By("When new pod is scheduled")
-			Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+			Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 
 			By("New service should be created with replace label pointing to old one")
 			Eventually(func() (map[string]string, error) {

--- a/test/integration/upgrade_version_test.go
+++ b/test/integration/upgrade_version_test.go
@@ -57,9 +57,9 @@ var _ = Describe("Cluster controller", func() {
 		// Cluster should be scaled sequentially up to member count
 		for _, rack := range scylla.Spec.Datacenter.Racks {
 			for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
-				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 				Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
-				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 			}
 		}
 
@@ -129,7 +129,7 @@ var _ = Describe("Cluster controller", func() {
 			rack := scylla.Spec.Datacenter.Racks[0]
 			for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
 				Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
-				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 			}
 
 			originalActionsNewSessionFunc = actions.NewSessionFunc
@@ -266,7 +266,7 @@ var _ = Describe("Cluster controller", func() {
 				}, shortWait).Should(Equal(int(rack.Members - 1)))
 
 				By("When: node pod comes up")
-				Expect(sstStub.CreatePodsPartition(ctx, scylla, nodeUnderUpgradeIdx)).To(Succeed())
+				Expect(sstStub.CreatePodsPartition(ctx, scylla, nodeUnderUpgradeIdx, false)).To(Succeed())
 
 				podList := &corev1.PodList{}
 				Expect(testEnv.List(ctx, podList, &client.ListOptions{LabelSelector: naming.RackSelector(rack, scylla)})).To(Succeed())


### PR DESCRIPTION
This PR will provide MultiDC capability
It will be split in 3 parts:

- Usage of host IP so the host IP will be advertise to all cluster member. Currently the advertise IP for cluster member is the service cluster IP which is only avaiable for internal nodes

- Provide CRD capability to define seeds so we can advertise other DC seeds. It will rely on the same mechanism than internal seeds, which means relying on creation of a specific service with seed label

- Provide a mechanism to define a initCluster. Idea here is to ensure that only one of the DC cluster can bootstrap from local seed. The other DC cluster will wait for the external seed to be available (not relying on internal seeds)
