### PR TITLE
Update helm crd with multiDcCluster

### DIFF
--- a/helm/scylla-operator/crds/scylla.scylladb.com_scyllaclusters.yaml
+++ b/helm/scylla-operator/crds/scylla.scylladb.com_scyllaclusters.yaml
@@ -1435,6 +1435,18 @@ spec:
                   description: PollInterval specifies how often upgrade logic polls on state updates. Increasing this value should lower number of requests sent to apiserver, but it may affect overall time spent during upgrade.
                   type: string
               type: object
+            multiDcCluster:
+              description: Configuration for multi DC cluster
+              properties:
+                initCluster:
+                  description: Indicate if this cluster is the initial cluster. Init cluster rely on local seeds while non init one only rely on multi dc seeds during bootstrap and then on local seeds only.
+                  type: boolean
+                seeds:
+                  description: List of seeds.
+                  items:
+                    type: string
+                  type: array
+              type: object
             network:
               description: Networking config
               properties:


### PR DESCRIPTION
The crd is stored in 2 different places config/operator/crd/bases and in helm/scylla-operator/crds
Sadly only the first one has been updated while we are relying on the second one in our deployment