### PR TITLE
Disable repository verification

### DIFF
--- a/pkg/api/v1/cluster_validation.go
+++ b/pkg/api/v1/cluster_validation.go
@@ -124,9 +124,10 @@ func checkValues(c *ScyllaCluster) error {
 
 func checkTransitions(old, new *ScyllaCluster) error {
 	// Check that repository remained the same
-	if !reflect.DeepEqual(old.Spec.Repository, new.Spec.Repository) {
-		return errors.Errorf("repository change is currently not supported, old=%v, new=%v", *old.Spec.Repository, *new.Spec.Repository)
-	}
+	// We actually want to be able to change the repository, it should retain equivalent tag scheme
+	// if !reflect.DeepEqual(old.Spec.Repository, new.Spec.Repository) {
+	// 	return errors.Errorf("repository change is currently not supported, old=%v, new=%v", *old.Spec.Repository, *new.Spec.Repository)
+	// }
 
 	// Check that the datacenter name didn't change
 	if old.Spec.Datacenter.Name != new.Spec.Datacenter.Name {


### PR DESCRIPTION
Repository verification is a big constraints when testing different images
This change remove the validation in the webhook
The operator will only update the image if the version of the image is also changed