### PR TITLE
Ignore unsupported sysctls

### DIFF
--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -478,7 +478,7 @@ func sysctlInitContainer(sysctls []string) *corev1.Container {
 		Command: []string{
 			"/bin/sh",
 			"-c",
-			fmt.Sprintf("sysctl -w %s", strings.Join(sysctls, " ")),
+			fmt.Sprintf("sysctl -e -w %s", strings.Join(sysctls, " ")),
 		},
 	}
 }


### PR DESCRIPTION
Some sysctl aren't supported by all kernels and we might want to
support multiple versions of the kernel at the same time (typically
when upgrading kernel on a cluster).
