### PR TITLE
Add customLabels support on pods

### DIFF
--- a/helm/scylla-operator/crds/scylla.scylladb.com_scyllaclusters.yaml
+++ b/helm/scylla-operator/crds/scylla.scylladb.com_scyllaclusters.yaml
@@ -185,6 +185,11 @@ spec:
                         name:
                           description: Name of the Scylla Rack. Used in the cassandra-rackdc.properties file.
                           type: string
+                        customLabels:
+                          description: Labels to add on the pods
+                          additionalProperties:
+                            type: string
+                          type: object
                         placement:
                           description: Placement describes restrictions for the nodes Scylla is scheduled on.
                           properties:

--- a/pkg/api/v1/cluster_types.go
+++ b/pkg/api/v1/cluster_types.go
@@ -213,6 +213,8 @@ type RackSpec struct {
 	ScyllaConfig string `json:"scyllaConfig"`
 	// Scylla config map name to customize scylla manager agent
 	ScyllaAgentConfig string `json:"scyllaAgentConfig"`
+	// Labels to add on the pods
+	CustomLabels map[string]string `json:"customLabels"`
 }
 
 type PlacementSpec struct {

--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -2,10 +2,11 @@ package resource
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
 	"github.com/scylladb/scylla-operator/pkg/cmd/scylla-operator/options"
@@ -180,7 +181,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, sidecarI
 			// Template for Pods
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: rackLabels,
+					Labels: naming.PodSpecLabels(r, c),
 					Annotations: map[string]string{
 						naming.PrometheusScrapeAnnotation: naming.LabelValueTrue,
 						naming.PrometheusPortAnnotation:   "9180",

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -27,13 +27,21 @@ func DatacenterLabels(c *scyllav1.ScyllaCluster) map[string]string {
 }
 
 // RackLabels returns a map of label keys and values
-// for the given Rack.
+// for the given Rack to be used on selectors and pods
 func RackLabels(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) map[string]string {
 	recLabels := recommendedLabels()
 	rackLabels := DatacenterLabels(c)
 	rackLabels[RackNameLabel] = r.Name
 
 	return mergeLabels(rackLabels, recLabels)
+}
+
+// PodSpecLabels returns a map of label keys and values
+// for the given Rack to be used on pods
+func PodSpecLabels(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) map[string]string {
+	rackLabels := RackLabels(r, c)
+
+	return mergeLabels(rackLabels, r.CustomLabels)
 }
 
 // StatefulSetPodLabel returns a map of labels to uniquely

--- a/pkg/naming/labels_test.go
+++ b/pkg/naming/labels_test.go
@@ -1,0 +1,28 @@
+package naming
+
+import (
+	"testing"
+)
+
+func TestHelloName(t *testing.T) {
+	t1 := make(map[string]string)
+	t2 := make(map[string]string)
+	t1["t1"] = "t1"
+	t2["t2"] = "t2"
+	if len(mergeLabels(nil, nil)) != 0 {
+		t.Fatalf("merge of nil maps should be empty and not fail")
+	}
+
+	res := mergeLabels(t1, nil)
+	if res["t1"] != "t1" {
+		t.Fatalf("merge with nil map incorrect")
+	}
+	res = mergeLabels(nil, t2)
+	if res["t2"] != "t2" {
+		t.Fatalf("merge with nil map incorrect")
+	}
+	res = mergeLabels(t1, t2)
+	if res["t1"] != "t1" || res["t2"] != "t2" {
+		t.Fatalf("merge of maps incorrect")
+	}
+}


### PR DESCRIPTION
Allow the configuration of labels on pods using RackSpec on scyllaCluster.
Note the change is only applied at cluster creation like most changes.

Change has been tested manually:
- no breaking on the crd
- operators support both versions of the CRD

The main risky area was on the merge function so added unittests to make sure it behaves well with nil maps

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #
