### PR TITLE
Add ServiceAccountName field to ClusterSpec

### DIFF
--- a/helm/scylla-operator/crds/scylla.scylladb.com_scyllaclusters.yaml
+++ b/helm/scylla-operator/crds/scylla.scylladb.com_scyllaclusters.yaml
@@ -1619,6 +1619,9 @@ spec:
               scyllaArgs:
                 description: ScyllaArgs will be appended to Scylla binary during startup. This is supported from 4.2.0 Scylla version.
                 type: string
+              serviceAccountName:
+                description: ServiceAccountName is the name of the ServiceAccount that Scylla member pods will run under. When empty, the operator falls back to "<clusterName>-member", preserving the historical default.
+                type: string
               sysctls:
                 description: 'Sysctl properties to be applied during initialization given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
                 items:

--- a/pkg/api/v1/cluster_types.go
+++ b/pkg/api/v1/cluster_types.go
@@ -66,6 +66,10 @@ type ClusterSpec struct {
 	// MultiDcCluster configuration for multi DC cluster
 	// Specifies the external seed to use
 	MultiDcCluster *MultiDcClusterSpec `json:"multiDcCluster,omitempty"`
+	// ServiceAccountName is the name of the ServiceAccount that Scylla member pods
+	// will run under. When empty, the operator falls back to "<clusterName>-member",
+	// preserving the historical default.
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // GenericUpgradeFailureStrategy allows to specify how upgrade logic should handle failures.

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -44,6 +44,9 @@ func ServiceDNSName(service string, c *scyllav1.ScyllaCluster) string {
 }
 
 func ServiceAccountNameForMembers(c *scyllav1.ScyllaCluster) string {
+	if c.Spec.ServiceAccountName != "" {
+		return c.Spec.ServiceAccountName
+	}
 	return fmt.Sprintf("%s-member", c.Name)
 }
 

--- a/pkg/naming/names_test.go
+++ b/pkg/naming/names_test.go
@@ -1,0 +1,50 @@
+package naming
+
+import (
+	"testing"
+
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestServiceAccountNameForMembers(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *scyllav1.ScyllaCluster
+		want    string
+	}{
+		{
+			name: "defaults to <name>-member when ServiceAccountName is unset (backward compat for existing clusters)",
+			cluster: &scyllav1.ScyllaCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+				Spec:       scyllav1.ClusterSpec{},
+			},
+			want: "my-cluster-member",
+		},
+		{
+			name: "returns the custom ServiceAccountName when set",
+			cluster: &scyllav1.ScyllaCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+				Spec:       scyllav1.ClusterSpec{ServiceAccountName: "custom-sa"},
+			},
+			want: "custom-sa",
+		},
+		{
+			name: "empty string is treated as unset and falls back to default",
+			cluster: &scyllav1.ScyllaCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+				Spec:       scyllav1.ClusterSpec{ServiceAccountName: ""},
+			},
+			want: "my-cluster-member",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ServiceAccountNameForMembers(tt.cluster)
+			if got != tt.want {
+				t.Fatalf("ServiceAccountNameForMembers() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow operators to override the ServiceAccount used by Scylla member pods via a new optional ClusterSpec.serviceAccountName field. When empty, behavior is unchanged: pods continue to run under "<clusterName>-member".

Why the rollout is safe for existing clusters:

- The field is optional with `omitempty`. Existing ScyllaCluster objects in etcd don't carry it, so ServiceAccountNameForMembers() keeps returning "<clusterName>-member". The StatefulSet pod template is byte-identical to before, which means no rolling restart is triggered by upgrading the operator.
- The CRD change is purely additive (new optional string, no required fields, no schema tightening), so an older operator binary reading a CR authored against the new CRD just ignores the unknown field -- no validation failure during a staggered rollout.
- A plain `string` (not `*string`) means no zz_generated.deepcopy.go regeneration is needed; the existing struct assignment covers it.

RoleBinding considerations:

- The operator does NOT create the ServiceAccount or its RBAC. Those are managed out of band (see examples/generic/cluster.yaml for the default "<clusterName>-member" SA, Role, and RoleBinding).
- When setting a custom serviceAccountName, you must create the SA in the same namespace as the ScyllaCluster and grant it at least the same permissions the default "<clusterName>-member" SA has today (the sidecar uses this SA to read/patch pods and services). The simplest path is a new RoleBinding that binds the existing Role ("<clusterName>-member") to the new SA, rather than duplicating the rules.
- Setting serviceAccountName on an already-running cluster WILL change the pod template and trigger a rolling restart of every rack's StatefulSet. Create and bind the new SA before flipping the field, otherwise pods may come back up unable to talk to the API server.