### PR TITLE
Reconcile spec-derived pod-template changes onto rack StatefulSets

### DIFF
--- a/pkg/controllers/cluster/actions/pod_template_update.go
+++ b/pkg/controllers/cluster/actions/pod_template_update.go
@@ -1,0 +1,167 @@
+// Copyright (C) 2026 ScyllaDB
+
+package actions
+
+import (
+	"github.com/pkg/errors"
+	"github.com/scylladb/go-log"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+const (
+	PodTemplateUpdateAction = "pod-template-update"
+)
+
+// PodTemplateUpdate propagates spec-derived pod-template settings from the
+// cluster spec onto rack StatefulSets when they diverge. It reconciles a
+// curated subset of fields that govern scheduling, identity, labelling, and
+// container resources:
+//
+//   - ServiceAccountName (plus the legacy "serviceAccount" alias)
+//   - Affinity (node/pod/anti-pod)
+//   - Tolerations
+//   - Pod template labels (RackLabels + spec.CustomLabels)
+//   - Per-container Resources, matched by container name
+//
+// Image-related fields are intentionally out of scope: SidecarUpgrade and the
+// version-upgrade action own those and run earlier in nextAction. Volumes and
+// network mode are also out of scope; they involve more invasive changes that
+// deserve dedicated handling.
+type PodTemplateUpdate struct {
+	cluster      *scyllav1.ScyllaCluster
+	sidecarImage string
+}
+
+func (a *PodTemplateUpdate) RackUpdated(rack scyllav1.RackSpec, sts *appsv1.StatefulSet) (bool, error) {
+	desired := resource.StatefulSetForRack(rack, a.cluster, a.sidecarImage)
+	return !managedPodTemplateDiverged(sts, desired), nil
+}
+
+func (a *PodTemplateUpdate) Update(rack scyllav1.RackSpec, sts *appsv1.StatefulSet) error {
+	desired := resource.StatefulSetForRack(rack, a.cluster, a.sidecarImage)
+	wantSpec := desired.Spec.Template.Spec
+	actualSpec := &sts.Spec.Template.Spec
+
+	actualSpec.ServiceAccountName = wantSpec.ServiceAccountName
+	// Keep DeprecatedServiceAccount (JSON: "serviceAccount") in sync. The apiserver
+	// rejects updates when both fields are set to different values, and read-back of
+	// an existing pod template typically populates this legacy alias via defaulting.
+	actualSpec.DeprecatedServiceAccount = wantSpec.ServiceAccountName
+
+	actualSpec.Affinity = wantSpec.Affinity
+	actualSpec.Tolerations = wantSpec.Tolerations
+
+	sts.Spec.Template.ObjectMeta.Labels = desired.Spec.Template.ObjectMeta.Labels
+
+	if err := applyContainerResources(actualSpec.Containers, wantSpec.Containers); err != nil {
+		return errors.Wrap(err, "apply container resources")
+	}
+
+	// Force RollingUpdate so the mutation actually rolls pods. The STS may have
+	// been left in OnDelete by a previously crashed version-upgrade action; the
+	// rackSynchronized readiness check (UpdateRevision==CurrentRevision) cannot
+	// converge under OnDelete from a pod-template mutation alone.
+	sts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.RollingUpdateStatefulSetStrategyType,
+	}
+	return nil
+}
+
+func NewPodTemplateUpdate(c *scyllav1.ScyllaCluster, sidecarImage string, l log.Logger) *rackSynchronizedAction {
+	return &rackSynchronizedAction{
+		subAction: NewPodTemplateUpdateSubAction(c, sidecarImage),
+		cluster:   c,
+		logger:    l,
+	}
+}
+
+// NewPodTemplateUpdateSubAction exposes the rack-level diff/apply primitive so
+// callers (e.g. nextAction) can probe whether any rack diverges without first
+// constructing the full rack-synchronized wrapper.
+func NewPodTemplateUpdateSubAction(c *scyllav1.ScyllaCluster, sidecarImage string) *PodTemplateUpdate {
+	return &PodTemplateUpdate{
+		cluster:      c,
+		sidecarImage: sidecarImage,
+	}
+}
+
+func (a *PodTemplateUpdate) Name() string {
+	return PodTemplateUpdateAction
+}
+
+// managedPodTemplateDiverged returns true when any field this action owns
+// diverges between actual and desired. Keep this set aligned with Update.
+func managedPodTemplateDiverged(actual, desired *appsv1.StatefulSet) bool {
+	actualSpec := actual.Spec.Template.Spec
+	wantSpec := desired.Spec.Template.Spec
+
+	if actualSpec.ServiceAccountName != wantSpec.ServiceAccountName {
+		return true
+	}
+	// The apiserver populates DeprecatedServiceAccount on read via defaulting,
+	// so once set it must agree with ServiceAccountName or k8s validation will
+	// reject the next update.
+	if actualSpec.DeprecatedServiceAccount != "" && actualSpec.DeprecatedServiceAccount != wantSpec.ServiceAccountName {
+		return true
+	}
+	if !apiequality.Semantic.DeepEqual(actualSpec.Affinity, wantSpec.Affinity) {
+		return true
+	}
+	if !apiequality.Semantic.DeepEqual(actualSpec.Tolerations, wantSpec.Tolerations) {
+		return true
+	}
+	if !apiequality.Semantic.DeepEqual(actual.Spec.Template.ObjectMeta.Labels, desired.Spec.Template.ObjectMeta.Labels) {
+		return true
+	}
+	if containerResourcesDiverge(actualSpec.Containers, wantSpec.Containers) {
+		return true
+	}
+	// If a previous upgrade left the STS in OnDelete, a template mutation would
+	// not roll pods on its own. Treat that as a divergence so we converge back
+	// to RollingUpdate together with any field change.
+	if actual.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+		return true
+	}
+	return false
+}
+
+// containerResourcesDiverge reports whether any container present in both
+// actual and want (matched by name) has different Resources. Containers that
+// exist only on one side are ignored: container set management belongs to
+// StatefulSetForRack / dedicated actions, not this one.
+func containerResourcesDiverge(actual, want []corev1.Container) bool {
+	byName := make(map[string]corev1.ResourceRequirements, len(want))
+	for _, c := range want {
+		byName[c.Name] = c.Resources
+	}
+	for _, c := range actual {
+		wantRes, ok := byName[c.Name]
+		if !ok {
+			continue
+		}
+		if !apiequality.Semantic.DeepEqual(c.Resources, wantRes) {
+			return true
+		}
+	}
+	return false
+}
+
+// applyContainerResources copies Resources from want into matching containers
+// in actual (matched by name). Containers in actual that have no counterpart
+// in want are left untouched.
+func applyContainerResources(actual, want []corev1.Container) error {
+	byName := make(map[string]corev1.ResourceRequirements, len(want))
+	for _, c := range want {
+		byName[c.Name] = c.Resources
+	}
+	for i := range actual {
+		if r, ok := byName[actual[i].Name]; ok {
+			actual[i].Resources = r
+		}
+	}
+	return nil
+}

--- a/pkg/controllers/cluster/actions/pod_template_update_test.go
+++ b/pkg/controllers/cluster/actions/pod_template_update_test.go
@@ -1,0 +1,183 @@
+// Copyright (C) 2026 ScyllaDB
+
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scylladb/go-log"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
+	clusterresource "github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// executeAndGet runs the action against a fake client seeded with `sts`, then
+// returns the post-update STS so tests can assert on it.
+func executeAndGet(t *testing.T, cluster *scyllav1.ScyllaCluster, sts *appsv1.StatefulSet) *appsv1.StatefulSet {
+	t.Helper()
+	ctx := context.Background()
+	logger, _ := log.NewProduction(log.Config{
+		Level: zap.NewAtomicLevelAt(zapcore.DebugLevel),
+	})
+	kubeClient := fake.NewSimpleClientset([]runtime.Object{sts}...)
+	a := NewPodTemplateUpdate(cluster, "image", logger)
+	if err := a.Execute(ctx, &State{kubeclient: kubeClient}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := kubeClient.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, sts.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get sts: %s", err)
+	}
+	return got
+}
+
+func TestPodTemplateUpdate_ServiceAccountAndLegacyAlias(t *testing.T) {
+	const newSA = "custom-sa"
+
+	cluster := unit.NewMultiRackCluster(1)
+	cluster.Spec.ServiceAccountName = newSA
+
+	rackSts := clusterresource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, "image")
+	// Wind back to the historical default so the action has something to reconcile,
+	// and pre-populate the legacy alias as the apiserver would after defaulting.
+	rackSts.Spec.Template.Spec.ServiceAccountName = "test-cluster-member"
+	rackSts.Spec.Template.Spec.DeprecatedServiceAccount = "test-cluster-member"
+
+	got := executeAndGet(t, cluster, rackSts)
+	if got.Spec.Template.Spec.ServiceAccountName != newSA {
+		t.Fatalf("ServiceAccountName=%q, want %q", got.Spec.Template.Spec.ServiceAccountName, newSA)
+	}
+	if got.Spec.Template.Spec.DeprecatedServiceAccount != newSA {
+		t.Fatalf("DeprecatedServiceAccount=%q, want %q (legacy alias must stay in sync)",
+			got.Spec.Template.Spec.DeprecatedServiceAccount, newSA)
+	}
+}
+
+func TestPodTemplateUpdate_TolerationsAffinityLabels(t *testing.T) {
+	cluster := unit.NewMultiRackCluster(1)
+	rack := &cluster.Spec.Datacenter.Racks[0]
+
+	rack.Placement = &scyllav1.PlacementSpec{
+		Tolerations: []corev1.Toleration{{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "scylla", Effect: corev1.TaintEffectNoSchedule}},
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "role", Operator: corev1.NodeSelectorOpIn, Values: []string{"db"},
+					}},
+				}},
+			},
+		},
+	}
+	rack.CustomLabels = map[string]string{"team": "data"}
+
+	// Build an STS as it existed *before* the user added placement/customLabels —
+	// without those fields the actual rack sts diverges from desired.
+	staleCluster := unit.NewMultiRackCluster(1)
+	staleSts := clusterresource.StatefulSetForRack(staleCluster.Spec.Datacenter.Racks[0], staleCluster, "image")
+
+	got := executeAndGet(t, cluster, staleSts)
+
+	if !apiequality.Semantic.DeepEqual(got.Spec.Template.Spec.Tolerations, rack.Placement.Tolerations) {
+		t.Fatalf("Tolerations not propagated: got %+v, want %+v",
+			got.Spec.Template.Spec.Tolerations, rack.Placement.Tolerations)
+	}
+	if !apiequality.Semantic.DeepEqual(got.Spec.Template.Spec.Affinity.NodeAffinity, rack.Placement.NodeAffinity) {
+		t.Fatalf("NodeAffinity not propagated: got %+v, want %+v",
+			got.Spec.Template.Spec.Affinity.NodeAffinity, rack.Placement.NodeAffinity)
+	}
+	if v, ok := got.Spec.Template.ObjectMeta.Labels["team"]; !ok || v != "data" {
+		t.Fatalf("CustomLabels not propagated to pod template labels: got %v", got.Spec.Template.ObjectMeta.Labels)
+	}
+}
+
+func TestPodTemplateUpdate_ContainerResources(t *testing.T) {
+	cluster := unit.NewMultiRackCluster(1)
+	rack := &cluster.Spec.Datacenter.Racks[0]
+	rack.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4"),
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
+		},
+	}
+	rack.AgentResources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+
+	staleCluster := unit.NewMultiRackCluster(1)
+	staleSts := clusterresource.StatefulSetForRack(staleCluster.Spec.Datacenter.Racks[0], staleCluster, "image")
+
+	got := executeAndGet(t, cluster, staleSts)
+
+	scylla := findContainer(t, got.Spec.Template.Spec.Containers, "scylla")
+	if !apiequality.Semantic.DeepEqual(scylla.Resources, rack.Resources) {
+		t.Fatalf("Scylla container Resources not propagated: got %+v, want %+v", scylla.Resources, rack.Resources)
+	}
+	agent := findContainer(t, got.Spec.Template.Spec.Containers, "scylla-manager-agent")
+	if !apiequality.Semantic.DeepEqual(agent.Resources, rack.AgentResources) {
+		t.Fatalf("Agent container Resources not propagated: got %+v, want %+v", agent.Resources, rack.AgentResources)
+	}
+}
+
+func TestPodTemplateUpdate_ForcesRollingUpdate(t *testing.T) {
+	// Simulate the operator crashing mid version-upgrade with the STS left on
+	// OnDelete: a template mutation alone would never roll pods, and the
+	// rackSynchronized readiness check would never converge.
+	cluster := unit.NewMultiRackCluster(1)
+	cluster.Spec.ServiceAccountName = "custom-sa"
+
+	rackSts := clusterresource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, "image")
+	rackSts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.OnDeleteStatefulSetStrategyType,
+	}
+
+	got := executeAndGet(t, cluster, rackSts)
+	if got.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+		t.Fatalf("UpdateStrategy=%q, want %q", got.Spec.UpdateStrategy.Type, appsv1.RollingUpdateStatefulSetStrategyType)
+	}
+}
+
+func TestPodTemplateUpdate_NoopWhenInSync(t *testing.T) {
+	// When desired and actual already match, RackUpdated must be true so that
+	// nextAction does not pick this path on every reconcile loop.
+	cluster := unit.NewMultiRackCluster(1)
+	rack := cluster.Spec.Datacenter.Racks[0]
+	rackSts := clusterresource.StatefulSetForRack(rack, cluster, "image")
+
+	sub := NewPodTemplateUpdateSubAction(cluster, "image")
+	updated, err := sub.RackUpdated(rack, rackSts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatalf("RackUpdated reported divergence for an STS freshly built from the same spec")
+	}
+}
+
+func findContainer(t *testing.T, cs []corev1.Container, name string) corev1.Container {
+	t.Helper()
+	for _, c := range cs {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("container %q not found among %d containers", name, len(cs))
+	return corev1.Container{}
+}

--- a/pkg/controllers/cluster/actions/rack_synchronized.go
+++ b/pkg/controllers/cluster/actions/rack_synchronized.go
@@ -17,9 +17,9 @@ import (
 
 type rackSynchronizedSubAction interface {
 	// RackUpdated should return whether requested update is already applied to a rack sts.
-	RackUpdated(sts *appsv1.StatefulSet) (bool, error)
+	RackUpdated(rack scyllav1.RackSpec, sts *appsv1.StatefulSet) (bool, error)
 	// Update performs desired update.
-	Update(sts *appsv1.StatefulSet) error
+	Update(rack scyllav1.RackSpec, sts *appsv1.StatefulSet) error
 	// Name of action.
 	Name() string
 }
@@ -49,12 +49,12 @@ func (a rackSynchronizedAction) Execute(ctx context.Context, s *State) error {
 			return errors.Wrap(err, "get rack statefulset")
 		}
 
-		rackUpdated, err := a.subAction.RackUpdated(sts)
+		rackUpdated, err := a.subAction.RackUpdated(rack, sts)
 		if err != nil {
 			return errors.Wrap(err, "determine if rack needs update")
 		}
 		if !rackUpdated {
-			if err := a.subAction.Update(sts); err != nil {
+			if err := a.subAction.Update(rack, sts); err != nil {
 				return errors.Wrap(err, "update rack")
 			}
 

--- a/pkg/controllers/cluster/actions/rack_synchronized_test.go
+++ b/pkg/controllers/cluster/actions/rack_synchronized_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/scylladb/go-log"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	"go.uber.org/zap"
@@ -24,11 +25,11 @@ type subAction struct {
 	updateFunc  func(sts *appsv1.StatefulSet) error
 }
 
-func (a *subAction) RackUpdated(sts *appsv1.StatefulSet) (bool, error) {
+func (a *subAction) RackUpdated(_ scyllav1.RackSpec, sts *appsv1.StatefulSet) (bool, error) {
 	return a.updateState[sts.Name], nil
 }
 
-func (a *subAction) Update(sts *appsv1.StatefulSet) error {
+func (a *subAction) Update(_ scyllav1.RackSpec, sts *appsv1.StatefulSet) error {
 	a.updates = append(a.updates, sts.Name)
 	if a.updateFunc != nil {
 		return a.updateFunc(sts)

--- a/pkg/controllers/cluster/actions/sidecar_upgrade.go
+++ b/pkg/controllers/cluster/actions/sidecar_upgrade.go
@@ -19,7 +19,7 @@ type SidecarUpgrade struct {
 	sidecar corev1.Container
 }
 
-func (a *SidecarUpgrade) RackUpdated(sts *appsv1.StatefulSet) (bool, error) {
+func (a *SidecarUpgrade) RackUpdated(_ scyllav1.RackSpec, sts *appsv1.StatefulSet) (bool, error) {
 	sidecarIdx, err := naming.FindSidecarInjectorContainer(sts.Spec.Template.Spec.InitContainers)
 	if err != nil {
 		return false, errors.Wrap(err, "find sidecar container in pod")
@@ -28,7 +28,7 @@ func (a *SidecarUpgrade) RackUpdated(sts *appsv1.StatefulSet) (bool, error) {
 	return sts.Spec.Template.Spec.InitContainers[sidecarIdx].Image == a.sidecar.Image, nil
 }
 
-func (a *SidecarUpgrade) Update(sts *appsv1.StatefulSet) error {
+func (a *SidecarUpgrade) Update(_ scyllav1.RackSpec, sts *appsv1.StatefulSet) error {
 	initContainers := sts.Spec.Template.Spec.InitContainers
 	sidecarIdx, err := naming.FindSidecarInjectorContainer(initContainers)
 	if err != nil {

--- a/pkg/controllers/cluster/sync.go
+++ b/pkg/controllers/cluster/sync.go
@@ -143,6 +143,21 @@ func (cc *ClusterReconciler) nextAction(ctx context.Context, cluster *scyllav1.S
 		}
 	}
 
+	// Reconcile spec-derived pod-template settings (service account, scheduling,
+	// labels, container resources) onto rack StatefulSets when they diverge.
+	// This catches edits to spec fields that only StatefulSetForRack consumes at
+	// creation time, e.g. spec.serviceAccountName, rack.placement, rack.resources,
+	// rack.customLabels. Runs after sidecar/version upgrades so those fields are
+	// already converged before we compare here.
+	update, err := cc.podTemplateUpdateNeeded(ctx, cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "check if pod template update is needed")
+	}
+	if update {
+		logger.Info(ctx, "Next Action: Reconcile rack pod template")
+		return actions.NewPodTemplateUpdate(cluster, cc.OperatorImage, logger), nil
+	}
+
 	///////////////////////////////////////////////////////////////////////////////////////
 	// At this point, the cluster is in a stable state and ready to start another action //
 	///////////////////////////////////////////////////////////////////////////////////////
@@ -199,4 +214,23 @@ func (cc *ClusterReconciler) sidecarUpdateNeeded(ctx context.Context, rack scyll
 
 	return actualSidecarContainer.Image != desiredSidecarContainer.Image, desiredSidecarContainer, nil
 
+}
+
+func (cc *ClusterReconciler) podTemplateUpdateNeeded(ctx context.Context, cluster *scyllav1.ScyllaCluster) (bool, error) {
+	sub := actions.NewPodTemplateUpdateSubAction(cluster, cc.OperatorImage)
+	for _, rack := range cluster.Spec.Datacenter.Racks {
+		actualSts, err := util.GetStatefulSetForRack(ctx, rack, cluster, cc.KubeClient)
+		if err != nil {
+			return false, errors.Wrap(err, "fetch rack sts")
+		}
+		updated, err := sub.RackUpdated(rack, actualSts)
+		if err != nil {
+			return false, errors.Wrap(err, "check rack pod template")
+		}
+		if !updated {
+			cc.Logger.Debug(ctx, "Pod template update needed", "rack", rack.Name)
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
  ## Summary

  - The previous commit (`263d9125`) added `spec.serviceAccountName` to `ClusterSpec` but only wired it into `StatefulSetForRack`, so the field took effect at cluster creation only. Editing an existing `ScyllaCluster` updated the CR but the rack StatefulSets retained the old ServiceAccount and pods never restarted.
  - New `ServiceAccountUpdate` action (built on the existing `rackSynchronizedAction` pattern) that `nextAction` selects when the actual STS pod template diverges from  `naming.ServiceAccountNameForMembers`. The action runs rack-by-rack, mutates the pod template, and lets the STS controller roll the pods.

  ## Defensive details

  - Both `ServiceAccountName` and `DeprecatedServiceAccount` (`serviceAccount`) are rewritten together. The apiserver populates the legacy alias via defaulting on read, and validation rejects updates when the two fields disagree.
  - `UpdateStrategy` is forced back to `RollingUpdate`. A prior version-upgrade action temporarily switches racks to `OnDelete`; if the operator crashed mid-upgrade the STS can be left there, in which case a pod-template mutation alone would never roll the pods and the `rackSynchronized` readiness check (`UpdateRevision == CurrentRevision`) would
  never converge.
  - `nextAction`'s existing version-upgrade-in-progress branch fires before the new SA check, so we don't race a deliberate `OnDelete` window.

  ## No-op when `spec.serviceAccountName` is empty

  `ServiceAccountNameForMembers` still returns `"<clusterName>-member"`, the actual STS already matches, `serviceAccountUpdateNeeded` returns false, no action is created, and   the STS is not written